### PR TITLE
Comply with OpenAI server by making schema optional.

### DIFF
--- a/pylib/cli/server.py
+++ b/pylib/cli/server.py
@@ -125,7 +125,7 @@ class V1ResponseFormat(BaseModel):
     type: V1ResponseFormatType
     # schema is our addition, not an OpenAI API parameter
     # Avoid shadowing BaseModel.schema
-    json_schema: str = Field(alias='schema')
+    json_schema: Optional[str] = Field(default=None, alias='schema')
 
 
 class V1StreamOptions(BaseModel):


### PR DESCRIPTION
Using microsoft/graphrag, I was getting errors like

```
{"status_code":10422,"message":"[{'type': 'missing', 'loc': ('body', 'response_format', 'schema'), 'msg': 'Field required', 'input': {'type': 'json_object'}}]","data":null}
```

This query, while without an explicit schema, is a valid OpenAI query and should be supported:

```
curl -X POST "http://localhost:8000/v1/chat/completions" \
  -H 'Content-Type: application/json' \
  -d '{
    "messages": [{"role": "user", "content": "I am thinking of a number between 1 and 10. Guess what it is."}],
    "response_format": {
        "type": "json_object"
    },
    "temperature": 0.1
   }'
```