### PR TITLE
First pass at 'vendoring' llm_structured_output into Toolio

### DIFF
--- a/pylib/cli/server.py
+++ b/pylib/cli/server.py
@@ -33,7 +33,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import click
 import uvicorn
 
-from llm_structured_output.util.output import info, warning, debug
+from toolio.vendor.llm_structured_output.util.output import info, warning, debug
 
 from toolio.http_schematics import V1ChatCompletionsRequest
 from toolio.common import DEFAULT_FLAGS, FLAGS_LOOKUP

--- a/pylib/common.py
+++ b/pylib/common.py
@@ -15,7 +15,7 @@ from amara3 import iri
 
 # import mlx.core as mx
 # from mlx_lm.models import (gemma, gemma2, llama, phi, qwen, su_rope, minicpm, phi3, qwen2, gpt2,
-#                            mixtral, phi3small, qwen2_moe, cohere, gpt_bigcode, phixtral,
+#                            mixtral, phi3small, qwen2_moe, cohere, cohere2, gpt_bigcode, phixtral,
 #                            stablelm, dbrx, internlm2, openelm, plamo, starcoder2)
 
 # from mlx_lm.models import olmo  # Will say:: To run olmo install ai2-olmo: pip install ai2-olmo
@@ -32,6 +32,7 @@ class model_flag(Flag):
 DEFAULT_FLAGS = model_flag(0)
 
 # {model_class: flags}, defaults to DEFAULT_FLAGS
+# OK it seems as if model_flag.NO_SYSTEM_ROLE | model_flag.USER_ASSISTANT_ALT is the actual default!
 FLAGS_LOOKUP = {
     # Actually Llama seems to want asistant response rather than as tool
     # 'llama': model_flag.NO_SYSTEM_ROLE | model_flag.USER_ASSISTANT_ALT | model_flag.TOOL_RESPONSE,
@@ -41,6 +42,8 @@ FLAGS_LOOKUP = {
     'mixtral': model_flag.NO_SYSTEM_ROLE | model_flag.USER_ASSISTANT_ALT,
     'mistral': model_flag.NO_SYSTEM_ROLE | model_flag.USER_ASSISTANT_ALT,
     'qwen2': model_flag.NO_SYSTEM_ROLE | model_flag.USER_ASSISTANT_ALT,
+    'cohere': model_flag.NO_SYSTEM_ROLE | model_flag.USER_ASSISTANT_ALT,
+    'cohere2': model_flag.NO_SYSTEM_ROLE | model_flag.USER_ASSISTANT_ALT,
 }
 
 TOOLIO_MODEL_TYPE_FIELD = 'toolio.model_type'
@@ -50,7 +53,7 @@ DEFAULT_JSON_SCHEMA_CUTOUT = '#!JSON_SCHEMA!#'
 
 def load_or_connect(ref: str, **kwargs):
     '''
-    Sonvenience function to either load a module from a file or HuggingFace path,
+    Convenience function to either load a module from a file or HuggingFace path,
     or connect to a Toolio server, based on checking the provided reference string
 
     Parameters:

--- a/pylib/http_impl.py
+++ b/pylib/http_impl.py
@@ -8,7 +8,7 @@ Heart of the implementation for HTTP server request handling
 import json
 import warnings
 
-from llm_structured_output.util.output import info, debug
+from toolio.vendor.llm_structured_output.util.output import info, debug
 
 from toolio.common import prompt_handler
 from toolio.toolcall import DEFAULT_INTERNAL_TOOLS, process_tools_for_sysmsg

--- a/pylib/llm_helper.py
+++ b/pylib/llm_helper.py
@@ -183,7 +183,8 @@ class model_manager(toolcall_mixin):
         else:
             yield resp
 
-    async def complete(self, messages, stream=True, json_schema=None, max_tokens=128, temperature=0.1):
+    async def complete(self, messages, stream=True, json_schema=None, max_tokens=128, temperature=0.1,
+                       insert_schema=True):
         '''
         Simple completion without tools. Returns just the response text.
         If you want the full response object, use iter_complete directly
@@ -193,7 +194,7 @@ class model_manager(toolcall_mixin):
             **kwargs: Additional arguments passed to __call__
         '''
         async for resp in self.iter_complete(messages, json_schema=json_schema, stream=False, max_tokens=max_tokens,
-            temperature=temperature):
+                                             temperature=temperature, insert_schema=insert_schema):
             break
 
         if isinstance(resp, str):

--- a/pylib/schema_helper.py
+++ b/pylib/schema_helper.py
@@ -19,14 +19,14 @@ import mlx.core as mx
 from mlx_lm.models.cache import KVCache
 from mlx_lm.utils import load
 
-from llm_structured_output import JsonSchemaAcceptorDriver
-from llm_structured_output.util.bitmap import (
+from toolio.vendor.llm_structured_output import JsonSchemaAcceptorDriver
+from toolio.vendor.llm_structured_output.util.bitmap import (
     bias_logits,
     count_set_bits,
     enumerate_set_bits,
 )
-from llm_structured_output.util.output import debug
-from llm_structured_output.util.tokenization import HuggingfaceTokenizerHelper
+from toolio.vendor.llm_structured_output.util.output import debug
+from toolio.vendor.llm_structured_output.util.tokenization import HuggingfaceTokenizerHelper
 
 
 class RejectedCompletion(Exception):

--- a/pylib/vendor/__init__.py
+++ b/pylib/vendor/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024-present Oori Data <info@oori.dev>
+#
+# SPDX-License-Identifier: Apache-2.0
+# toolio.vendor

--- a/pylib/vendor/llm_structured_output/__init__.py
+++ b/pylib/vendor/llm_structured_output/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2024-present Oori Data <info@oori.dev>
+#
+# SPDX-License-Identifier: Apache-2.0
+# toolio.vendor.llm_structured_output
+from .json_schema_acceptor import JsonSchemaAcceptor, JsonSchemaAcceptorDriver

--- a/pylib/vendor/llm_structured_output/acceptor.py
+++ b/pylib/vendor/llm_structured_output/acceptor.py
@@ -1,0 +1,645 @@
+"""
+Base token acceptors.
+
+A token acceptor constrains the tokens that are acceptable at this point in
+the parsing or generation of a text.
+
+Since multiple parses of a given input may be possible (or multiple generations
+valid according to e.g. a schema), the acceptor creates multiple "cursors", one
+for each valid current state of the acceptor. This is akin to a chart parser,
+where all possible parses of the input are carried in parallel, which minimizes
+backtracking that is expensive on an LLM.
+
+The basic flow is:
+- First, the vocabulary (list of possible tokens for the LLM) is prepared into
+  a trie for logarithmic traversal. Subclasses may also perform their own
+  vocabulary preparation.
+- The acceptor's get_cursors() method is called, and the acceptor issues one or
+  more cursors with initial state(s).
+- The trie is traversed to find which tokens are a valid match in the current
+  state of the active cursor(s). For each cursor:
+  - The select() method is called to narrow down the next character(s) that the
+    cursor can accept in its current state.
+  - For each selected character, we advance() the cursor, obtaining one or more
+    follow-up cursors that represent the next state(s) of the cursor.
+  - We descend down the trie branch corresponding to the selected character, and
+    perform the same select(), advance() operation on the new cursor(s).
+  - We traverse until the cursor(s) have reached an accepted state or we reach a
+    leaf node.
+  - As we traverse the trie recursively, we collect the token ids for each node.
+    This creates a set of valid tokens that will be accepted.
+
+For example: if we have a TextAcceptor that will accept the word "true", the
+initial cursor's select() method will return "t" as the set of acceptable
+characters. We will then advance the cursor and obtain a cursor that accepts the
+word "rue", and our current trie node will become the "t" child branch of the
+prior trie node. We will then match the new trie node with the new acceptor, etc.
+
+Acceptors can be chained with e.g. a StateMachineAcceptor. In this case, when a
+cursor reaches a final state, the parent acceptor moves its own cursor forward,
+potentially issuing more cursors that can be matched with the remainder of the
+trie.
+
+Some methods have been added to help prevent combinatorial explosions while
+searching that can have a big effect in performance. For example, an acceptor
+for a quoted string can select() a very large amount of characters after the
+first quote. Descending upon every branch of the trie is not necessary in as
+much as every character is essentially equivalently valid. To avoid this, we
+allow the acceptor to prune the trie so that all equivalent characters are
+collapsed into one branch. In such a collapsed trie, each node keeps a set with
+all the ids for valid tokens of the same length, which are equivalent from the
+point of the view of the acceptor.
+"""
+
+from __future__ import annotations
+from copy import copy as shallowcopy
+from time import time_ns
+from typing import Iterable, Tuple
+
+from .util.tokentrie import TokenTrie
+
+
+class TokenAcceptor:
+    """
+    Base class for token acceptors.
+    """
+
+    @classmethod
+    def prepare_vocabulary(cls, vocabulary: Iterable[Tuple[int, str]]) -> TokenTrie:
+        """
+        Given a list of tokens (typically the vocabulary of an LLM), create
+        a trie that will be used to select the tokens accepted by the current
+        set of cursors.
+        """
+        vocabulary_trie = TokenTrie()
+        vocabulary_trie.insert_all(vocabulary)
+        return vocabulary_trie
+
+    @classmethod
+    def match_all(cls, cursors: Iterable[TokenAcceptor.Cursor], trie: TokenTrie) -> int:
+        """
+        Find which tokens in the vocabulary move any of the cursors towards an
+        acceptance state from their current state.
+        """
+        if any(cursor.matches_all() for cursor in cursors):
+            return trie.collect_ids()
+        bitmap = 0
+        for cursor in cursors:
+            bitmap |= cursor.match(trie)
+        return bitmap
+
+    @classmethod
+    def debug_match_all(
+        cls,
+        cursors: Iterable[TokenAcceptor.Cursor],
+        trie: TokenTrie,
+        debug_output_fn=print,
+    ) -> int:
+        """
+        Same as match_all() but outputs debug information.
+        """
+        if any(cursor.matches_all() for cursor in cursors):
+            return trie.collect_ids()
+        debug_output_fn("MATCH ALL")
+        bitmap = 0
+        for cursor in cursors:
+            start = time_ns()
+            cursor_matches = cursor.debug_match(trie, debug_output_fn)
+            dt_ns = time_ns() - start
+            match_count = bin(cursor_matches).count("1")
+            debug_output_fn(f"t={dt_ns/1e6:.02f}ms {match_count=} {repr(cursor)}")
+            bitmap |= cursor_matches
+        return bitmap
+
+    @classmethod
+    def advance_all(
+        cls, cursors: Iterable[TokenAcceptor.Cursor], char: str
+    ) -> list[TokenAcceptor.Cursor]:
+        """
+        Advance multiple cursors in parallel.
+        """
+        return [
+            new_cursor
+            for cursor in cursors
+            if char in cursor.select(set(char))
+            for new_cursor in cursor.advance(char)
+        ]
+
+    def get_cursors(self) -> Iterable[TokenAcceptor.Cursor]:
+        """
+        Get one or more cursors to traverse the acceptor.
+        Override.
+        """
+        return [self.__class__.Cursor(self)]
+
+    class Cursor:
+        """
+        A cursor encapsulates a valid current state of a token acceptor.
+        """
+
+        def __init__(self, acceptor: TokenAcceptor):
+            pass
+
+        def clone(self):
+            """
+            Cursors are never mutated, they are cloned as they advance.
+            They should also be lightweight: think twice before overriding this
+            to e.g. a deepcopy.
+            """
+            return shallowcopy(self)
+
+        def matches_all(self) -> bool:
+            """
+            The acceptor accepts all the tokens (i.e. free text).
+            This is an optimization and only useful for acceptors that don't constrain
+            the input, such as WaitForAcceptor.
+            """
+            return False
+
+        def select(self, candidate_chars: set[str]) -> Iterable[str]:
+            """
+            Narrow down the characters that are offered to the cursor for advancement.
+            This is a crucial performance improvement for cursors in a state where they'll
+            accept only a small set of characters, since they will be tested against that
+            set instead of the whole range of characters available.
+            Override.
+            """
+            return candidate_chars
+
+        # pylint: disable-next=unused-argument
+        def advance(self, char: str) -> Iterable[TokenAcceptor.Cursor]:
+            """
+            If the character can be consumed, return new cursor(s) for the possible
+            continuation(s). IMPORTANT: Cursors should not mutate their state, only
+            return mutated copies of the object, as the advance method is called
+            multiple times with different inputs. See clone() method above.
+            Override.
+            """
+            return []
+
+        def in_accepted_state(self) -> bool:
+            """
+            Returns True if the cursor has reached a final state.
+            Typically, rather than override you should return an AcceptedState object
+            in the advance() method when the state is reached after consuming input.
+            """
+            return False
+
+        def get_value(self):
+            """
+            Returns the current value of the cursor as defined by itself. This can be
+            either the ongoing representation of its temporary state, or its final value
+            usable for the application once it reaches accepted state. At that point,
+            cursors that return the same value are considered identical and duplicates
+            may be discarded for performance.
+            Override.
+            """
+            return None
+
+        def get_value_path(self):
+            """
+            Returns the path of the value being pointed at by the cursor as defined by the
+            application. This can be for example a JSON path in the case of a JSON acceptor.
+            For higher-level application purposes only, not required for accepting.
+            Override.
+            """
+            return ""
+
+        def is_in_value(self):
+            """
+            Returns true if the cursor is accepting a value as opposed to syntactic elements.
+            Used in conjunction with get_value_path().
+            Override.
+            """
+            return False
+
+        def prune(self, trie: TokenTrie) -> Iterable[(str, TokenTrie)]:
+            """
+            Select the children of the trie to search for matches. See match() below.
+            This can be overriden in order to e.g. use a collapsed trie.
+            """
+            if trie.children:
+                chars = set(trie.children.keys())
+                selected_chars = chars & set(self.select(chars))
+                for char in selected_chars:
+                    yield (char, trie.children[char])
+
+        def match(self, trie: TokenTrie) -> int:
+            """
+            Find which tokens in the vocabulary move the acceptor towards an acceptance
+            state from the current state held by this cursor.
+            Returns a bit map with the bits corresponding to the index if the matched
+            tokens set to 1.
+            """
+            if self.matches_all():
+                return trie.collect_ids()
+            bitmap = 0
+            for char, child in self.prune(trie):
+                followup_cursors = self.advance(char)
+                if followup_cursors:
+                    bitmap |= child.ids
+                    for followup_cursor in followup_cursors:
+                        bitmap |= followup_cursor.match(child)
+            return bitmap
+
+        def debug_match(
+            self, trie: TokenTrie, debug_output_fn=print, debug_indent=1
+        ) -> int:
+            """
+            Same as match() but outputs debug information
+            """
+            debug_start = time_ns()
+            if self.matches_all():
+                return trie.collect_ids()
+            bitmap = 0
+            debug_label = type(self).__qualname__
+            if isinstance(self, StateMachineAcceptor.Cursor):
+                debug_label += f"({type(self.transition_cursor).__qualname__})"
+            debug_prefix = "  " * debug_indent + debug_label
+            debug_prune_start = time_ns()
+            for char, child in self.prune(trie):
+                debug_advance_start = time_ns()
+                followup_cursors = self.advance(char)
+                debug_advance_end = time_ns()
+                prune_time = (debug_advance_start - debug_prune_start) / 1e6
+                advance_time = (debug_advance_end - debug_advance_start) / 1e6
+                debug_output_fn(
+                    f"{debug_prefix} >>> "
+                    f"{prune_time=:.02f}ms {advance_time=:.02f}ms char={repr(char)}"
+                )
+                debug_followup_start = time_ns()
+                if followup_cursors:
+                    bitmap |= child.ids
+                    for followup_cursor in followup_cursors:
+                        bitmap |= followup_cursor.debug_match(
+                            child, debug_output_fn, debug_indent + 1
+                        )
+                debug_followup_end = time_ns()
+                followup_time = (debug_followup_end - debug_followup_start) / 1e6
+                followup_count = len(followup_cursors)
+                match_count = bin(bitmap).count("1")
+                debug_output_fn(
+                    f"{debug_prefix} <<< {followup_count=} {followup_time=:.02f}ms {match_count=}"
+                )
+                debug_prune_start = time_ns()
+            total_time = (time_ns() - debug_start) / 1e6
+            debug_output_fn(f"{debug_prefix} {total_time=:.02f}ms")
+            return bitmap
+
+        def __repr__(self):
+            return f"{type(self).__qualname__}(value={repr(self.get_value())})"
+
+
+class AcceptedState(TokenAcceptor.Cursor):
+    """
+    Holds a cursor that has reached the accepted state.
+    """
+
+    def __init__(self, cursor: TokenAcceptor.Cursor):
+        self.cursor = cursor
+
+    def in_accepted_state(self):
+        return True
+
+    def get_value(self):
+        return self.cursor.get_value()
+
+    def __repr__(self):
+        return f"✅{repr(self.cursor)}"
+
+
+class CharAcceptor(TokenAcceptor):
+    """
+    Accept one character iff is in the set of expected characters.
+    """
+
+    def __init__(self, charset: Iterable[str]):
+        self.charset = charset
+
+    class Cursor(TokenAcceptor.Cursor):
+        """
+        Cursor for CharAcceptor
+        """
+
+        def __init__(self, acceptor, value=None):
+            self.acceptor = acceptor
+            self.value = value
+
+        def select(self, candidate_chars):
+            return self.acceptor.charset
+
+        def advance(self, char):
+            # Because we implemented the select method, we are guaranteed that the
+            # char is in our accepted set.
+            return [AcceptedState(self.__class__(self.acceptor, char))]
+
+        def get_value(self):
+            return self.value
+
+        def __repr__(self):
+            return f"charset={repr(self.acceptor.charset)} value={repr(self.value)}"
+
+
+class TextAcceptor(TokenAcceptor):
+    """
+    Accept a pre-determined string of characters.
+    """
+
+    def __init__(self, text: str):
+        assert len(text) > 0
+        self.text = text
+
+    class Cursor(TokenAcceptor.Cursor):
+        """
+        Cursor for TextAcceptor
+        """
+
+        def __init__(self, acceptor, pos=0):
+            self.acceptor = acceptor
+            self.pos = pos
+
+        def select(self, candidate_chars):
+            return self.acceptor.text[self.pos]
+
+        def advance(self, char):
+            next_cursor = self.__class__(self.acceptor, self.pos + 1)
+            if next_cursor.pos == len(self.acceptor.text):
+                return [AcceptedState(next_cursor)]
+            return [next_cursor]
+
+        def get_value(self) -> str:
+            head = self.acceptor.text[0 : self.pos]
+            tail = self.acceptor.text[self.pos :]
+            if len(tail):
+                return f"{head}👉{tail}"
+            else:
+                return f"{head}"
+
+
+class StateMachineAcceptor(TokenAcceptor):
+    """
+    Token acceptor that follows a state graph that defines edges to transition
+    from state to state. Each state can have multiple edges, defined by the
+    target state and a TokenAcceptor that, when reaching accepted state, causes
+    the state machine acceptor to move to the target state. This is repeated
+    until the state machine reaches a final state. Multiple transition paths
+    are explored in parallel.
+    """
+
+    def __init__(self, graph=None, initial_state=None, end_states=None):
+        self.graph = graph or []
+        self.initial_state = initial_state or 0
+        self.end_states = set(end_states or ["$"])
+
+    def get_edges(self, state):
+        """
+        Retrieve the graph edges for transitions out of this state.
+        Can be overriden for dynamic graphs.
+        """
+        return self.graph[state]
+
+    def get_cursors(self):
+        initial_cursor = self.Cursor(self)
+        initial_cursor.current_state = self.initial_state
+        return self._find_transitions(initial_cursor, [], set())
+
+    def _find_transitions(self, cursor, visited_states, traversed_edges):
+        try:
+            edges = self.get_edges(cursor.current_state)
+        except (KeyError, IndexError, TypeError):
+            assert cursor.current_state in self.end_states
+            return []
+        cursors = []
+        for transition_acceptor, target_state in edges:
+            if cursor.start_transition(transition_acceptor, target_state):
+                for transition_cursor in transition_acceptor.get_cursors():
+                    copy = cursor.clone()
+                    copy.transition_cursor = transition_cursor
+                    copy.target_state = target_state
+                    # Handle cursors that start in an accepted state,
+                    # e.g. EmptyTransition, WhitespaceAcceptor
+                    if transition_cursor.in_accepted_state():
+                        new_visited_states = visited_states + [cursor.current_state]
+                        assert target_state not in new_visited_states  # Infinite loop
+                        cursors += self._cascade_transition(
+                            copy, new_visited_states, traversed_edges
+                        )
+                    else:
+                        cursors.append(copy)
+        return cursors
+
+    def _cascade_transition(self, cursor, visited_states, traversed_edges):
+        assert cursor.transition_cursor.in_accepted_state()
+        # Copy before validation to allow for cursor mutation, e.g. storing the transition_value
+        cursors = []
+        copy: StateMachineAcceptor.Cursor = cursor.clone()
+        if copy.complete_transition(
+            copy.transition_cursor.get_value(),
+            copy.target_state,
+            copy.target_state in copy.acceptor.end_states,
+        ):
+            copy.current_state = copy.target_state
+            copy.target_state = None
+            copy.accept_history = copy.accept_history + [copy.transition_cursor.cursor]
+            copy.transition_cursor = None
+            copy.consumed_character_count = 0
+            # De-duplicate cursors that have reached the same state with the same value.
+            # This prevents combinatorial explosion because of e.g. empty transitions.
+            state_value = (copy.current_state, repr(copy.get_value()))
+            if state_value not in traversed_edges:
+                traversed_edges.add(state_value)
+                if copy.current_state in self.end_states:
+                    cursors.append(AcceptedState(copy))
+                cursors += self._find_transitions(copy, visited_states, traversed_edges)
+        return cursors
+
+    def advance_cursor(self, cursor, char):
+        """
+        Advance a cursor, and if it reaches accepted state, cause the state machine to transition.
+        """
+        next_cursors = []
+        traversed_edges = set()
+        for followup_cursor in cursor.transition_cursor.advance(char):
+            copy = cursor.clone()
+            copy.transition_cursor = followup_cursor
+            copy.consumed_character_count += 1
+            if followup_cursor.in_accepted_state():
+                next_cursors += self._cascade_transition(
+                    copy, [], traversed_edges
+                )
+            else:
+                next_cursors.append(copy)
+        return next_cursors
+
+    class Cursor(TokenAcceptor.Cursor):
+        """
+        Cursor for StateMachineAcceptor
+        """
+
+        def __init__(self, acceptor):
+            self.acceptor = acceptor
+            self.accept_history = []
+            self.current_state = None
+            self.transition_cursor = None
+            self.target_state = None
+            self.consumed_character_count = 0
+
+        def matches_all(self):
+            if self.transition_cursor is None:
+                return False
+            return self.transition_cursor.matches_all()
+
+        def select(self, candidate_chars):
+            if self.transition_cursor is None:
+                return set()
+            return self.transition_cursor.select(candidate_chars)
+
+        def prune(self, trie):
+            if self.transition_cursor is None:
+                return []
+            return self.transition_cursor.prune(trie)
+
+        def advance(self, char):
+            return self.acceptor.advance_cursor(self, char)
+
+        # pylint: disable-next=unused-argument
+        def start_transition(self, transition_acceptor, target_state) -> bool:
+            """
+            Override to prevent an edge to be traversed.
+            """
+            return True
+
+        def complete_transition(  # pylint: disable-next=unused-argument
+            self, transition_value, target_state, is_end_state
+        ) -> bool:
+            """
+            Override to perform additional checks on the acceptee and mutate the cursor
+            with the transition_value as appropriate.
+            """
+            return True
+
+        def get_value(self):
+            value = [
+                accepted_transition_cursor.get_value()
+                for accepted_transition_cursor in self.accept_history
+            ]
+            if self.transition_cursor is not None:
+                value.append(self.transition_cursor.get_value())
+            return value
+
+        def is_in_value(self):
+            if self.consumed_character_count > 0:
+                return self.transition_cursor.is_in_value()
+            return self.accept_history[-1].is_in_value() if self.accept_history else None
+
+        def get_value_path(self):
+            if self.consumed_character_count > 0:
+                return self.transition_cursor.get_value_path()
+            return self.accept_history[-1].get_value_path() if self.accept_history else ""
+
+        def __repr__(self) -> str:
+            if self.transition_cursor is not None:
+                transition_cursor = repr(self.transition_cursor)
+                target_state = self.target_state
+            else:
+                transition_cursor = "None"
+                target_state = "None"
+            if self.accept_history:
+                accept_history = []
+                for accepted_transition_cursor in self.accept_history:
+                    if isinstance(
+                        accepted_transition_cursor, StateMachineAcceptor.Cursor
+                    ):
+                        accept_history += accepted_transition_cursor.accept_history
+                    else:
+                        accept_history.append(accepted_transition_cursor)
+                history = repr(
+                    "".join(
+                        [
+                            str(accepted_transition_cursor.get_value())
+                            for accepted_transition_cursor in accept_history
+                        ]
+                    )
+                )
+            else:
+                history = ""
+            state = (
+                f"{history} {self.current_state}⇒{target_state}  {transition_cursor}"
+            )
+            return f"{type(self).__qualname__}({state})"
+
+    class EmptyTransitionAcceptor(TokenAcceptor):
+        """
+        Faux acceptor that allows to create empty transition edges in a state
+        machine graph for convenience in expressing complex graphs.
+        An empty edge skips the current state altogether, without the need to
+        consume input.
+        """
+
+        def get_cursors(self):
+            return [AcceptedState(self.Cursor(self))]
+
+        class Cursor(TokenAcceptor.Cursor):
+            """
+            Cursor for EmptyTransitionAcceptor
+            """
+
+            def get_value(self):
+                return ""
+
+    # Singleton EmptyTransitionAcceptor
+    EmptyTransition = EmptyTransitionAcceptor()
+
+
+class SequenceAcceptor(StateMachineAcceptor):
+    """
+    Chain acceptors in sequence
+    """
+
+    def __init__(self, acceptors):
+        graph = [[(acceptor, i + 1)] for i, acceptor in enumerate(acceptors)]
+        super().__init__(graph, initial_state=0, end_states=[len(acceptors)])
+
+    class Cursor(StateMachineAcceptor.Cursor):
+        """
+        Cursor for SequenceAcceptor. Defined for inspectability.
+        """
+
+
+class WaitForAcceptor(TokenAcceptor):
+    """
+    Accept all text until finding a segment that triggers another acceptor.
+    This is useful to allow for free text until a delimiter is found, e.g.
+    when the output of an LLM includes JSON that is encapsulated within a
+    ```json ... ``` block.
+    """
+
+    def __init__(self, wait_for_acceptor: TokenAcceptor):
+        self.wait_for_acceptor = wait_for_acceptor
+
+    class Cursor(TokenAcceptor.Cursor):
+        """
+        Cursor for WaitForAcceptor
+        """
+
+        def __init__(self, acceptor, cursors=None):
+            self.acceptor = acceptor
+            if cursors:
+                self.cursors = cursors
+            else:
+                self.cursors = acceptor.wait_for_acceptor.get_cursors()
+
+        def matches_all(self):
+            return True
+
+        def advance(self, char):
+            cursors = TokenAcceptor.advance_all(self.cursors, char)
+            accepted_cursors = [
+                cursor for cursor in cursors if cursor.in_accepted_state()
+            ]
+            if accepted_cursors:
+                return accepted_cursors
+            return [self.__class__(self.acceptor, cursors)]
+
+        def get_value(self):
+            return f"Waiting for {repr(self.cursors)}"

--- a/pylib/vendor/llm_structured_output/json_acceptor.py
+++ b/pylib/vendor/llm_structured_output/json_acceptor.py
@@ -1,0 +1,587 @@
+"""
+Acceptors for JSON parsing or constraning LLM generation to JSON outputs.
+"""
+
+import json
+
+from .acceptor import (
+    TokenAcceptor,
+    AcceptedState,
+    CharAcceptor,
+    StateMachineAcceptor,
+    SequenceAcceptor,
+    TextAcceptor,
+)
+from .util.tokentrie import TokenTrie
+
+
+class WhitespaceTokenTrie(TokenTrie):
+    """
+    Create a smaller trie by collapsing all whitespace to a single symbol.
+    Since all whitespace is equivalent in JSON, tokens that only differ in
+    the type of whitespace are equivalent from a semantic point of view.
+
+    For example, the tokens "\n\n\n", "\t\t\t" and "  " are all mapped to the same
+    node root -> " " -> " " -> " ", which now contains the token ids of all three
+    tokens in its set of ids.
+
+    This allows us to reduce the number of equivalent branches we explore when
+    finding valid tokens. Note that this doesn't limit the possible output of
+    an LLM, since the token ids are kept in the trie and thus matched as valid,
+    and are accepted by the acceptor.
+    """
+
+    @classmethod
+    def from_trie(cls, trie, whitespace_charset):
+        """
+        Create a WhitespaceTokenTrie given a full vocabulary trie.
+        """
+        if isinstance(trie, WhitespaceTokenTrie):
+            return trie
+
+        def _whitespace_collapse_fn(char, level):
+            if char in whitespace_charset:
+                return " "
+            if level == 0:
+                # The trie doesn't need to contain tokens that don't start with whitespace,
+                # since they won't be selected by the WhitespaceAcceptor.
+                return None
+            return True
+
+        # pylint: disable-next=protected-access
+        return trie._map(_whitespace_collapse_fn, WhitespaceTokenTrie())
+
+
+class WhitespaceAcceptor(TokenAcceptor):
+    """
+    Optional whitespace
+    """
+
+    WHITESPACE = " \n\r\t"
+
+    _cached_tries = {}
+
+    @classmethod
+    def prepare_trie(cls, trie: TokenTrie):
+        """
+        Build a collapsed trie that reduces the search space for valid tokens.
+        """
+        trie_id = id(trie)
+        if trie_id in cls._cached_tries:
+            return cls._cached_tries[trie_id]
+        collapsed_trie = WhitespaceTokenTrie.from_trie(
+            trie, WhitespaceAcceptor.WHITESPACE
+        )
+        cls._cached_tries[trie_id] = collapsed_trie
+        return collapsed_trie
+
+    def __init__(self, max_whitespace: int = 40):
+        self.max_whitespace = max_whitespace
+
+    def get_cursors(self):
+        # Whitespace is optional
+        cursor = WhitespaceAcceptor.Cursor(self)
+        return [cursor, AcceptedState(cursor)]
+
+    class Cursor(TokenAcceptor.Cursor):
+        """
+        Cursor for WhitespaceAcceptor
+        """
+
+        def __init__(self, acceptor, text=""):
+            self.acceptor = acceptor
+            self.text = text
+            self.length_exceeded = len(text) > self.acceptor.max_whitespace
+
+        def select(self, candidate_chars):
+            if self.length_exceeded:
+                return set()
+            return WhitespaceAcceptor.WHITESPACE
+
+        def prune(self, trie):
+            """
+            Use a custom matching trie to collapse all equivalent whitespace
+            into one, saving time when selecting valid tokens.
+            """
+            collapsed_trie = WhitespaceAcceptor.prepare_trie(trie)
+            return super().prune(collapsed_trie)
+
+        def advance(self, char):
+            # Sometimes, LLMs try to run away with spaces when they don't know how to continue.
+            # If the LLM triggers this often, consider whether the LLM is suitable for emitting
+            # JSON and/or whether the task is achievable and makes sense with the information
+            # provided in the prompt.
+            if self.length_exceeded:
+                return []
+            next_cursor = WhitespaceAcceptor.Cursor(self.acceptor, self.text + char)
+            # More whitespace is optional
+            return [next_cursor, AcceptedState(next_cursor)]
+
+        def get_value(self):
+            return self.text
+
+
+class BooleanAcceptor(StateMachineAcceptor):
+    """
+    Accepts a JSON boolean value: true, false
+    """
+
+    def __init__(self):
+        super().__init__([[(TextAcceptor("true"), "$"), (TextAcceptor("false"), "$")]])
+
+    class Cursor(StateMachineAcceptor.Cursor):
+        """
+        Cursor for BooleanAcceptor
+        """
+
+        def __init__(self, acceptor):
+            super().__init__(acceptor)
+            self.value = None
+
+        def complete_transition(self, transition_value, target_state, is_end_state):
+            if is_end_state:
+                if transition_value == "true":
+                    self.value = True
+                else:
+                    assert transition_value == "false"
+                    self.value = False
+            return True
+
+        def get_value(self):
+            return self.value
+
+        def is_in_value(self):
+            return True
+
+
+class NullAcceptor(TextAcceptor):
+    """
+    Accepts the JSON null value
+    """
+
+    def __init__(self):
+        super().__init__("null")
+
+    class Cursor(TextAcceptor.Cursor):
+        """
+        Cursor for NullAcceptor
+        """
+
+        def is_in_value(self):
+            return True
+
+
+DigitAcceptor = CharAcceptor("0123456789")
+HexDigitAcceptor = CharAcceptor("0123456789ABCDEFabcdef")
+
+
+class StringCharTokenTrie(TokenTrie):
+    """
+    Create a smaller trie by collapsing all unescaped valid string characters
+    to a single one while keeping the token ids. This is useful to reduce
+    combinatorial explosion in string acceptance when all strings of equal
+    length are equally acceptable.
+    """
+
+    @classmethod
+    def from_trie(cls, trie):
+        """
+        Create a StringCharTokenTrie given a full trie.
+        """
+        if isinstance(trie, StringCharTokenTrie):
+            return trie
+
+        def _string_char_acceptor_collapse_fn(char, _level):
+            if char in ['"', "\\"]:
+                return True
+            if char in StringCharAcceptor.INVALID_CHARS:
+                return None
+            return "."
+
+        # pylint: disable-next=protected-access
+        return trie._map(_string_char_acceptor_collapse_fn, StringCharTokenTrie())
+
+
+class StringCharAcceptor(TokenAcceptor):
+    """
+    Accepts a valid JSON unescaped string character
+    """
+
+    INVALID_CHARS = set(chr(c) for c in range(0, 0x20)) | set(['"', "\\"])
+    _cached_tries = {}
+
+    @classmethod
+    def prepare_trie(cls, trie: TokenTrie):
+        """
+        Build a collapsed trie that reduces the search space for valid tokens.
+        Note that while there is only one main vocabulary trie, we may need to
+        several collapsed tries because sometimes string matching will start
+        in the middle of the main trie. I.e. we ara half way through the main
+        trie with another acceptor; that acceptor reaches an end state and then
+        we transition to the string acceptor; thus we start string matching in
+        the middle of the main trie instead of the root. This can happen e.g.
+        if there's tokens in the vocabulary that contain a quote and then
+        additional characters afterwards.
+        """
+        trie_id = id(trie)
+        if trie_id in cls._cached_tries:
+            return cls._cached_tries[trie_id]
+        collapsed_trie = StringCharTokenTrie().from_trie(trie)
+        cls._cached_tries[trie_id] = collapsed_trie
+        return collapsed_trie
+
+    class Cursor(TokenAcceptor.Cursor):
+        """
+        Cursor for StringCharAcceptor
+        """
+
+        def __init__(self, acceptor, value=None):
+            self.acceptor = acceptor
+            self.value = value
+
+        def select(self, candidate_chars):
+            return candidate_chars - StringCharAcceptor.INVALID_CHARS
+
+        def prune(self, trie):
+            """
+            Use a custom matching trie to avoid an explosion of valid options that
+            are equivalent from the point of view of token matching.
+            """
+            return super().prune(StringCharAcceptor.prepare_trie(trie))
+
+        def advance(self, char):
+            return [AcceptedState(StringCharAcceptor.Cursor(self.acceptor, char))]
+
+        def get_value(self):
+            return self.value
+
+
+class StringAcceptor(StateMachineAcceptor):
+    """
+    Accepts a well-formed JSON string
+    """
+
+    STATES = [
+        [(CharAcceptor('"'), 1)],
+        [(CharAcceptor('"'), "$"), (CharAcceptor("\\"), 2), (StringCharAcceptor(), 1)],
+        [
+            (CharAcceptor('"\\/bfnrt'), 1),
+            (CharAcceptor("u"), 3),
+        ],
+        [(HexDigitAcceptor, 4)],
+        [(HexDigitAcceptor, 5)],
+        [(HexDigitAcceptor, 6)],
+        [(HexDigitAcceptor, 1)],
+    ]
+
+    def __init__(self):
+        super().__init__(StringAcceptor.STATES)
+
+    class Cursor(StateMachineAcceptor.Cursor):
+        """
+        Cursor for StringAcceptor
+        """
+
+        def __init__(self, acceptor):
+            super().__init__(acceptor)
+            self.text = ""
+            self.length = 0
+            self.value = None
+
+        def complete_transition(self, transition_value, target_state, is_end_state):
+            self.text += transition_value
+            if target_state == 1 and self.current_state != 0:
+                self.length += 1
+            if is_end_state:
+                self.value = json.loads(self.text)
+            return True
+
+        def get_value(self):
+            if self.value is not None:
+                return self.value
+            else:
+                return f"{self.text}👉"
+
+        def is_in_value(self):
+            return True
+
+
+class StringConstantAcceptor(TextAcceptor):
+    """
+    Accept a constant string, quoted and escaped.
+    """
+
+    def __init__(self, string: str):
+        self.string = string
+        super().__init__(json.dumps(string))
+
+    class Cursor(TextAcceptor.Cursor):
+        """
+        Cursor for StringConstantAcceptor
+        """
+
+        def get_value(self) -> str:
+            if self.pos == len(self.acceptor.text):
+                return self.acceptor.string
+            return super().get_value()
+
+        def is_in_value(self):
+            return True
+
+
+class NumberTokenTrie(TokenTrie):
+    """
+    Create a smaller trie by collapsing digit sequences.
+    """
+
+    @classmethod
+    def from_trie(cls, trie):
+        """
+        Create a NumberTokenTrie given a full trie.
+        """
+        if isinstance(trie, NumberTokenTrie):
+            return trie
+
+        def _number_acceptor_collapse_fn(char, level):
+            if char in "0123456789":
+                return "9"
+            # Only store branches that start with a digit.
+            return level > 0
+
+        # pylint: disable-next=protected-access
+        return trie._map(_number_acceptor_collapse_fn, StringCharTokenTrie())
+
+
+class NumberAcceptor(StateMachineAcceptor):
+    """
+    Accepts a well-formed JSON number
+    """
+
+    STATES = {
+        0: [(CharAcceptor("-"), 1), (StateMachineAcceptor.EmptyTransition, 1)],  # Sign
+        1: [(CharAcceptor("123456789"), 2), (CharAcceptor("0"), 3)],  # First digit
+        2: [
+            (DigitAcceptor, 2),
+            (StateMachineAcceptor.EmptyTransition, 3),
+        ],  # More digits
+        3: [(CharAcceptor("."), 4), (StateMachineAcceptor.EmptyTransition, 6)],
+        4: [(DigitAcceptor, 5)],  # First decimal
+        5: [
+            (DigitAcceptor, 5),
+            (StateMachineAcceptor.EmptyTransition, 6),
+        ],  # More decimals
+        6: [(CharAcceptor("eE"), 7)],
+        7: [(CharAcceptor("+-"), 8), (StateMachineAcceptor.EmptyTransition, 8)],
+        8: [(DigitAcceptor, 9)],  # Exponential, first digit
+        9: [(DigitAcceptor, 9)],  # Exponential, more digits
+        "$": [2, 3, 5, 9],
+    }
+    _cached_tries = {}
+
+    @classmethod
+    def prepare_trie(cls, trie: TokenTrie):
+        """
+        Build a collapsed trie that reduces the search space for valid tokens.
+        """
+        trie_id = id(trie)
+        if trie_id in cls._cached_tries:
+            return cls._cached_tries[trie_id]
+        collapsed_trie = NumberTokenTrie().from_trie(trie)
+        cls._cached_tries[trie_id] = collapsed_trie
+        return collapsed_trie
+
+    def __init__(self):
+        super().__init__(self.STATES, 0, self.STATES["$"])
+
+    class Cursor(StateMachineAcceptor.Cursor):
+        """
+        Cursor for NumberAcceptor
+        """
+
+        def __init__(self, acceptor):
+            super().__init__(acceptor)
+            self.text = ""
+            self.value = None
+
+        def prune(self, trie):
+            """
+            Use a custom matching trie to avoid an explosion of valid options that
+            are equivalent from the point of view of token matching.
+            """
+            return super().prune(NumberAcceptor.prepare_trie(trie))
+
+        def complete_transition(self, transition_value, target_state, is_end_state):
+            self.text += transition_value
+            if is_end_state:
+                self.value = json.loads(self.text)
+            return True
+
+        def get_value(self):
+            if self.value is None:
+                return f"{self.text}👉"
+            return self.value
+
+        def is_in_value(self):
+            return True
+
+
+class ArrayAcceptor(StateMachineAcceptor):
+    """
+    Accepts a well-formed JSON array
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def get_edges(self, state):
+        return {
+            0: [(TextAcceptor("["), 1)],
+            1: [(WhitespaceAcceptor(), 2), (TextAcceptor("]"), "$")],
+            2: [(JsonAcceptor(), 3)],
+            3: [(WhitespaceAcceptor(), 4)],
+            4: [
+                (SequenceAcceptor([TextAcceptor(","), WhitespaceAcceptor()]), 2),
+                (TextAcceptor("]"), "$"),
+            ],
+        }[state]
+
+    class Cursor(StateMachineAcceptor.Cursor):
+        """
+        Cursor for ArrayAcceptor
+        """
+
+        def __init__(self, acceptor):
+            super().__init__(acceptor)
+            self.value = []
+
+        def clone(self):
+            c = super().clone()
+            c.value = self.value[:]
+            return c
+
+        def complete_transition(
+            self, transition_value, target_state, is_end_state
+        ) -> bool:
+            if self.current_state == 2:
+                self.value.append(transition_value)
+            return True
+
+        def get_value_path(self):
+            index = len(self.value)
+            if self.current_state > 2:
+                index -= 1
+            return f"[{index}]{super().get_value_path()}"
+
+
+class ObjectAcceptor(StateMachineAcceptor):
+    """
+    Accepts a well-formed JSON object
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def get_edges(self, state):
+        return {
+            0: [(TextAcceptor("{"), 1)],
+            1: [(self.EmptyTransition, 2), (self.EmptyTransition, 6)],
+            2: [(WhitespaceAcceptor(), 3)],
+            3: [(ObjectAcceptor.PropertyAcceptor(), 4)],
+            4: [(WhitespaceAcceptor(), 5)],
+            5: [(TextAcceptor(","), 2), (self.EmptyTransition, 7)],
+            6: [(WhitespaceAcceptor(), 7)],
+            7: [(TextAcceptor("}"), "$")],
+        }[state]
+
+    class Cursor(StateMachineAcceptor.Cursor):
+        """
+        Cursor for ObjectAcceptor
+        """
+
+        def __init__(self, acceptor):
+            super().__init__(acceptor)
+            self.value = {}
+
+        def complete_transition(
+            self, transition_value, target_state, is_end_state
+        ) -> bool:
+            if self.current_state == 3:
+                prop_name, prop_value = transition_value
+                self.value[prop_name] = prop_value
+            return True
+
+        def get_value(self):
+            return self.value
+
+    class PropertyAcceptor(SequenceAcceptor):
+        """
+        JSON object property acceptor
+        """
+
+        def __init__(self, graph=None):
+            if graph is None:
+                graph = [
+                    StringAcceptor(),
+                    WhitespaceAcceptor(),
+                    TextAcceptor(":"),
+                    WhitespaceAcceptor(),
+                    JsonAcceptor(),
+                ]
+            super().__init__(graph)
+
+        class Cursor(SequenceAcceptor.Cursor):
+            """
+            Cursor for ObjectAcceptor.PropertyAcceptor
+            """
+
+            def __init__(self, acceptor):
+                super().__init__(acceptor)
+                self.prop_name = None
+                self.prop_value = None
+
+            def complete_transition(
+                self, transition_value, target_state, is_end_state
+            ) -> bool:
+                if target_state == 1:
+                    self.prop_name = transition_value
+                elif is_end_state:
+                    self.prop_value = transition_value
+                return True
+
+            def get_value(self):
+                return (self.prop_name, self.prop_value)
+
+            def is_in_value(self):
+                return self.current_state >= 4 and super().is_in_value()
+
+            def get_value_path(self):
+                return f".{self.prop_name}{super().get_value_path()}"
+
+
+class JsonAcceptor(StateMachineAcceptor):
+    """
+    Acceptor for a JSON value
+    """
+
+    def get_edges(self, state):
+        if state == 0:
+            return [
+                (BooleanAcceptor(), "$"),
+                (NumberAcceptor(), "$"),
+                (StringAcceptor(), "$"),
+                (NullAcceptor(), "$"),
+                (ObjectAcceptor(), "$"),
+                (ArrayAcceptor(), "$"),
+            ]
+        return []
+
+
+def prepare_json_acceptor_tries(trie: TokenTrie):
+    """
+    Pre-cache custom acceptor tries.
+    """
+    WhitespaceAcceptor.prepare_trie(trie)
+    NumberAcceptor.prepare_trie(trie)
+    StringCharAcceptor.prepare_trie(trie)
+    if '"' in trie.children:
+        StringCharAcceptor.prepare_trie(trie.children['"'])

--- a/pylib/vendor/llm_structured_output/json_schema_acceptor.py
+++ b/pylib/vendor/llm_structured_output/json_schema_acceptor.py
@@ -1,0 +1,807 @@
+"""
+Acceptors for JSON schema validation or constraning LLM generation to JSON
+outputs complying with a JSON schema.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import Iterable, Tuple
+
+from .acceptor import (
+    TokenAcceptor,
+    StateMachineAcceptor,
+    SequenceAcceptor,
+    TextAcceptor,
+    WaitForAcceptor,
+)
+from .json_acceptor import (
+    WhitespaceAcceptor,
+    BooleanAcceptor,
+    NullAcceptor,
+    StringAcceptor,
+    StringConstantAcceptor,
+    NumberAcceptor,
+    ArrayAcceptor,
+    ObjectAcceptor,
+    prepare_json_acceptor_tries,
+)
+from .util.tokentrie import TokenTrie
+
+
+class SchemaNotImplementedError(Exception):
+    """
+    Raised when a JSON schema uses a feature that hasn't been implemented here yet
+    """
+
+
+class InvalidSchemaError(Exception):
+    """
+    Raised when the passed JSON schema is invalid, e.g. a required property is not defined
+    """
+
+
+# pylint: disable-next=invalid-name
+def ConstSchemaAcceptor(schema: dict):
+    """
+    Accept a constant string
+    """
+    return StringConstantAcceptor(schema["const"])
+
+
+class EnumSchemaAcceptor(StateMachineAcceptor):
+    """
+    Accept one of several constant strings
+    """
+
+    def __init__(self, schema: dict):
+        super().__init__(
+            [[(StringConstantAcceptor(value), "$") for value in schema["enum"]]]
+        )
+
+
+class StringSchemaAcceptor(StringAcceptor):
+    """
+    Accept a JSON string that conforms to a JSON schema
+    """
+
+    def __init__(self, schema: dict = None):
+        super().__init__()
+        self.schema = schema or {}
+
+    def min_length(self):
+        """
+        Returns the minimum string length according to the schema
+        """
+        return self.schema.get("minLength", 0)
+
+    def max_length(self):
+        """
+        Returns the maximum string length according to the schema
+        """
+        return self.schema.get("maxLength", 10000)  # Arbitrary default
+
+    def validate_value(self, value):
+        """
+        Validate the string value according to the schema
+        """
+        if len(value) < self.min_length():
+            return False
+        if len(value) > self.max_length():
+            return False
+        if "pattern" in self.schema:
+            # This would be better done progressively as the cursor advances
+            regex = re.compile(self.schema["pattern"])
+            if regex.search(value) is None:
+                return False
+        if "format" in self.schema:
+            raise SchemaNotImplementedError("string.format")
+        return True
+
+    class Cursor(StringAcceptor.Cursor):
+        """
+        Cursor for StringSchemaAcceptor
+        """
+
+        def __init__(self, acceptor):
+            super().__init__(acceptor)
+            self.acceptor = acceptor
+
+        def start_transition(self, transition_acceptor, target_state):
+            if self.current_state == 1:
+                if target_state == "$":
+                    return self.length >= self.acceptor.min_length()
+                else:
+                    return self.length < self.acceptor.max_length()
+            return True
+
+        def complete_transition(self, transition_value, target_state, is_end_state):
+            if not super().complete_transition(
+                transition_value, target_state, is_end_state
+            ):
+                return False
+            if is_end_state:
+                return self.acceptor.validate_value(self.get_value())
+            return True
+
+
+class NumberSchemaAcceptor(NumberAcceptor):
+    """
+    Accept a JSON number that conforms to a JSON schema
+    """
+
+    def __init__(self, schema):
+        super().__init__()
+        self.schema = schema
+        self.is_integer = schema["type"] == "integer"
+        self.requires_validation = any(
+            constraint in schema
+            for constraint in [
+                "minimum",
+                "exclusiveMinimum",
+                "maximum",
+                "exclusiveMaximum",
+                "multipleOf",
+            ]
+        )
+
+    def validate_value(self, value):
+        """
+        Validate the number value according to the schema
+        """
+        if "minimum" in self.schema and value < self.schema["minimum"]:
+            return False
+        if (
+            "exclusiveMinimum" in self.schema
+            and value <= self.schema["exclusiveMinimum"]
+        ):
+            return False
+        if "maximum" in self.schema and value > self.schema["maximum"]:
+            return False
+        if (
+            "exclusiveMaximum" in self.schema
+            and value >= self.schema["exclusiveMaximum"]
+        ):
+            return False
+        if "multipleOf" in self.schema:
+            divisor = self.schema["multipleOf"]
+            if value / divisor != value // divisor:
+                return False
+        return True
+
+    class Cursor(NumberAcceptor.Cursor):
+        """
+        Cursor for NumberAcceptor
+        """
+
+        def __init__(self, acceptor):
+            super().__init__(acceptor)
+            self.acceptor = acceptor
+
+        def prune(self, trie):
+            """
+            The parent class uses a collapsed trie and this means in the token-matching
+            phase we are always getting numbers made up of the digit "9", which prevents
+            correct validation. If we actually have anything to validate, we disable it.
+            """
+            if self.acceptor.requires_validation:
+                return super(NumberAcceptor.Cursor, self).prune(trie)
+            return super().prune(trie)
+
+        def start_transition(self, transition_acceptor, target_state):
+            if (
+                self.acceptor.is_integer
+                and self.current_state == 3
+                and target_state == 4
+            ):
+                return False
+            return super().start_transition(transition_acceptor, target_state)
+
+        def complete_transition(self, transition_value, target_state, is_end_state):
+            if not super().complete_transition(
+                transition_value, target_state, is_end_state
+            ):
+                return False
+            if is_end_state:
+                return self.acceptor.validate_value(self.get_value())
+            return True
+
+
+class ArraySchemaAcceptor(ArrayAcceptor):
+    """
+    TODO
+    {
+      "type": "array",
+      "items": { "type": "number" },
+      "uniqueItems": true
+    }
+    {
+      "type": "array",
+      "prefixItems": [
+        { "type": "number" },
+        { "type": "string" },
+        { "enum": ["Street", "Avenue", "Boulevard"] },
+        { "enum": ["NW", "NE", "SW", "SE"] }
+      ],
+      "items": { "type": "string" } # Constrain additional items to type string
+      "items": false # Do not allow items beyond the prefixItem
+      "unevaluatedItems": false # All prefixItems are required
+      "unevaluatedItems": { "const": "N/A" } # Default value for prefixItems
+    }
+    {
+      "type": "array",
+      "contains": {
+        "type": "number" # Contains at least one number
+      },
+      "minContains": 2, # Must contain at least two numbers
+      "maxContains": 3 # Must contain at most three numbers
+    }
+    """
+
+    def __init__(self, schema, context):
+        self.schema = schema
+        self.context = context
+        super().__init__()
+
+    def get_edges(self, state):
+        return {
+            0: lambda: [(TextAcceptor("["), 1)],
+            1: lambda: [(WhitespaceAcceptor(), 2), (TextAcceptor("]"), "$")],
+            2: lambda: [(JsonSchemaAcceptor(self.schema["items"], self.context), 3)],
+            3: lambda: [(WhitespaceAcceptor(), 4)],
+            4: lambda: [
+                (SequenceAcceptor([TextAcceptor(","), WhitespaceAcceptor()]), 2),
+                (TextAcceptor("]"), "$"),
+            ],
+        }[state]()
+
+    def min_items(self) -> int:
+        """
+        Returns the minimum number of items in the array, according to the schema
+        """
+        return self.schema.get("minItems", 0)
+
+    def max_items(self) -> int:
+        """
+        Returns the maximum number of items in the array, according to the schema
+        """
+        return self.schema.get("maxItems", 2**32)  # Arbitrary default
+
+    class Cursor(ArrayAcceptor.Cursor):
+        """
+        Cursor for ArrayAcceptor
+        """
+
+        def __init__(self, acceptor):
+            super().__init__(acceptor)
+            self.acceptor = acceptor
+
+        def start_transition(self, transition_acceptor, target_state) -> bool:
+            if self.current_state == 4 and target_state == 2:
+                return len(self.value) < self.acceptor.max_items()
+            if target_state == "$":
+                return len(self.value) >= self.acceptor.min_items()
+            return True
+
+
+class ObjectSchemaAcceptor(ObjectAcceptor):
+    """
+    TODO
+    {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "credit_card": { "type": "number" },
+        "billing_address": { "type": "string" }
+      },
+      "required": ["name"],
+      "dependentRequired": {
+        "credit_card": ["billing_address"]
+      }
+      "dependentSchemas": { # Alternative to dependentRequired
+        "credit_card": {
+          "properties": {
+            "billing_address": { "type": "string" }
+          },
+          "required": ["billing_address"]
+        }
+      }
+    }
+    {
+      "type": "object",
+      "properties": {
+        "street_address": {
+          "type": "string"
+        },
+        "country": {
+          "default": "United States of America",
+          "enum": ["United States of America", "Canada"]
+        }
+      },
+      "if": {
+        "properties": {
+          "country": { "const": "United States of America" }
+        }
+      },
+      "then": {
+        "properties": {
+          "postal_code": { "pattern": "[0-9]{5}(-[0-9]{4})?" }
+        }
+      },
+      "else": {
+        "properties": {
+          "postal_code": { "pattern": "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]" }
+        }
+      }
+    }
+    """
+
+    # $defs, $ref https://json-schema.org/understanding-json-schema/structuring
+
+    def __init__(self, schema, context):
+        self.schema = schema
+        self.context = context
+        self.properties = schema.get("properties", {})
+        # Note that, according to the JSON schema specification, additional properties
+        # should be allowed by default. The additionalProperties subschema can be used
+        # to limit this. But we default to only allowing the properties defined in the
+        # schema, because generally we don't want the LLM to generate at will. An
+        # exception to this is when no properties are defined in the schema; in that
+        # case we don't use this class but the superclass to allow any JSON object. 
+        if schema.get("additionalProperties"):
+            raise SchemaNotImplementedError("object.additionalProperties")
+        self.required_property_names = schema.get("required", [])
+        for required_property_name in self.required_property_names:
+            if required_property_name not in self.properties:
+                raise InvalidSchemaError(f"Required property '{required_property_name}' not defined")
+        
+        assert self.properties is not None
+        super().__init__()
+
+    def get_edges(self, state):
+        if state == 3:
+            return [
+                (
+                    ObjectSchemaAcceptor.PropertyAcceptor(
+                        prop_name, prop_schema, self.context
+                    ),
+                    4,
+                )
+                for prop_name, prop_schema in self.properties.items()
+            ]
+        else:
+            return super().get_edges(state)
+
+    class Cursor(ObjectAcceptor.Cursor):
+        """
+        Cursor for ObjectAcceptor
+        """
+
+        def __init__(self, acceptor):
+            super().__init__(acceptor)
+            self.acceptor = acceptor
+
+        def start_transition(self, transition_acceptor, target_state) -> bool:
+            if target_state == "$":
+                return all(
+                    prop_name in self.value
+                    for prop_name in self.acceptor.required_property_names
+                )
+            if self.current_state == 3 and target_state == 4:
+                # Is a property already set?
+                return transition_acceptor.prop_name not in self.value
+            if self.current_state == 5 and target_state == 2:
+                # Are all allowed properties already set?
+                return len(self.value.keys()) < len(self.acceptor.properties)
+            return True
+
+    class PropertyAcceptor(ObjectAcceptor.PropertyAcceptor):
+        """
+        Acceptor for an object property according to the schema
+        """
+
+        def __init__(self, prop_name, prop_schema, context):
+            self.prop_name = prop_name
+            self.prop_schema = prop_schema
+            self.prop_context = {
+                "defs": context["defs"],
+                "path": f"{context['path']}/{prop_name}",
+            }
+            super().__init__(
+                [
+                    StringConstantAcceptor(self.prop_name),
+                    WhitespaceAcceptor(),
+                    TextAcceptor(":"),
+                    WhitespaceAcceptor(),
+                    JsonSchemaAcceptor(self.prop_schema, self.prop_context),
+                ]
+            )
+
+        class Cursor(ObjectAcceptor.PropertyAcceptor.Cursor):
+            """
+            Cursor for ObjectSchemaAcceptor.PropertyAcceptor
+            """
+
+            def __init__(self, acceptor):
+                super().__init__(acceptor)
+                self.acceptor = acceptor
+
+            def complete_transition(
+                self, transition_value, target_state, is_end_state
+            ) -> bool:
+                if not super().complete_transition(
+                    transition_value, target_state, is_end_state
+                ):
+                    return False
+                hooks = self.acceptor.prop_schema.get("__hooks", None)
+                if hooks:
+                    prop_name = self.acceptor.prop_name
+                    if target_state == 4 and "value_start" in hooks:
+                        hooks["value_start"](prop_name)
+                    elif is_end_state and "value_end" in hooks:
+                        hooks["value_end"](prop_name, transition_value)
+                return True
+
+            def get_value(self):
+                return (self.acceptor.prop_name, self.prop_value)
+
+
+class AnyOfAcceptor(StateMachineAcceptor):
+    """
+    Accepts JSON input that complies with any of several provided JSON schemas
+    """
+
+    def __init__(self, schemas: list[dict], context):
+        super().__init__(
+            [[(JsonSchemaAcceptor(schema, context), "$") for schema in schemas]]
+        )
+
+
+def merged(dict1, dict2):
+    """
+    Returns a new dictionary resulting from the merge of two input dictionaries
+    """
+    copy = dict1.copy()
+    copy.update(dict2)
+    return copy
+
+
+class DefinitionNotFoundError(Exception):
+    """
+    Raised when a JSON schema reference cannot be resolved.
+    """
+
+    def __init__(self, ref: str):
+        super().__init__(f"Definition not found for schema reference '{ref}'")
+
+
+def resolve_subschemas(schema, defs, visited_refs) -> list:
+    """
+    Resolve JSON schema references and schema combination keywords (allOf, anyOf, oneOf)
+    """
+    if "$ref" in schema:
+        schema_ref = schema["$ref"]
+        if schema_ref in visited_refs:
+            return visited_refs[schema_ref]
+        resolved_schema = []
+        visited_refs[schema_ref] = resolved_schema
+        schema_def = defs.get(schema_ref)
+        if schema_def is None:
+            raise DefinitionNotFoundError(schema_ref)
+        resolved_schema += resolve_subschemas(schema_def, defs, visited_refs)
+        return resolved_schema
+
+    if "allOf" in schema:
+        merged_schema = schema.copy()
+        del merged_schema["allOf"]
+        # Resolve any other keywords ("anyOf", "oneOf", ...) before adding subschemas.
+        schemas = resolve_subschemas(merged_schema, defs, visited_refs)
+        for subschema in schema["allOf"]:
+            schemas = [
+                merged(ms, rs)
+                for ms in schemas
+                for rs in resolve_subschemas(subschema, defs, visited_refs)
+            ]
+        return schemas
+
+    if "anyOf" in schema:
+        merged_schema = schema.copy()
+        del merged_schema["anyOf"]
+        # Resolve any other keywords ("allOf", "oneOf", ...) before adding subschemas.
+        merged_schemas = resolve_subschemas(merged_schema, defs, visited_refs)
+        return [
+            merged(ms, rs)
+            for subschema in schema["anyOf"]
+            for rs in resolve_subschemas(subschema, defs, visited_refs)
+            for ms in merged_schemas
+        ]
+
+    if "oneOf" in schema:
+        # The "oneOf" keyword requires matching one of the subschemas, while _not_ matching
+        # any of the others. Similarly to "not", the general case is out of scope.
+        # Since many use cases are equivalent, we treat this keyword as an synonym of "anyOf".
+        merged_schema = schema.copy()
+        del merged_schema["oneOf"]
+        # Resolve any other keywords ("allOf", "anyOf", ...) before adding subschemas.
+        merged_schemas = resolve_subschemas(merged_schema, defs, visited_refs)
+        return [
+            merged(ms, rs)
+            for subschema in schema["oneOf"]
+            for rs in resolve_subschemas(subschema, defs, visited_refs)
+            for ms in merged_schemas
+        ]
+
+    return [schema]
+
+
+class UnknownSchemaTypeError(Exception):
+    """
+    Raised when a JSON schema doesn't contain a known type.
+    """
+
+    def __init__(self, schema):
+        super().__init__(f"Unknown schema type for schema: {schema}")
+
+
+# pylint: disable-next=invalid-name
+def JsonSchemaAcceptor(schema, context=None):
+    """
+    Accept JSON according to a schema
+    """
+    if context is None:
+        context = {"defs": defaultdict(dict), "path": ""}
+
+    if schema.get("nullable"):
+        non_nullable = schema.copy()
+        del non_nullable["nullable"]
+        return AnyOfAcceptor([{"type": "null"}, non_nullable], context)
+
+    if "$defs" in schema:
+        schema_defs = schema["$defs"]
+        if "$id" in schema_defs:
+            raise SchemaNotImplementedError("$defs.$id")
+        for def_name, def_schema in schema_defs.items():
+            # Not clear whether defs are relative or absolute, do both
+            context["defs"][f"#/$defs{context['path']}/{def_name}"] = def_schema
+            context["defs"][f"#/$defs/{def_name}"] = def_schema
+
+    schemas = resolve_subschemas(schema, context["defs"], {})
+    if len(schemas) == 1:
+        schema = schemas[0]
+    else:
+        return AnyOfAcceptor(schemas, context)
+
+    if "not" in schema:
+        # Since this is for autoregressive generation, it doesn't make sense to get an LLM
+        # to generate something in order to then negate its validity in retrospect. Thus,
+        # supporting the "not" keyword in the general case is out of scope.
+        # Some use cases of "not" could be handled, like rejecting generation of certain
+        # values for primitive types, e.g. a boolean or string value.
+        raise SchemaNotImplementedError("not")
+
+    schema_type = schema.get("type")
+
+    if isinstance(schema_type, list):
+        return AnyOfAcceptor(
+            [merged(schema, {"type": type}) for type in schema_type], context
+        )
+
+    # Be robust with loosely-defined schemas
+    if schema_type is None:
+        if "properties" in schema:
+            schema_type = "object"
+        elif "items" in schema:
+            schema_type = "array"
+
+    if schema_type == "boolean":
+        acceptor = BooleanAcceptor()
+    elif schema_type == "number":
+        acceptor = NumberSchemaAcceptor(schema)
+    elif schema_type == "integer":
+        acceptor = NumberSchemaAcceptor(schema)
+    elif schema_type == "string":
+        acceptor = StringSchemaAcceptor(schema)
+    elif schema_type == "null":
+        acceptor = NullAcceptor()
+    elif "const" in schema:
+        acceptor = ConstSchemaAcceptor(schema)
+    elif "enum" in schema:
+        acceptor = EnumSchemaAcceptor(schema)
+    elif schema_type == "object":
+        if "properties" in schema:
+            # Only allows named properties in the object.
+            # See comment in constructor.
+            acceptor = ObjectSchemaAcceptor(schema, context)
+        else:
+            # Allows any properties in the object.
+            acceptor = ObjectAcceptor()
+    elif schema_type == "array":
+        if "items" in schema:
+            acceptor = ArraySchemaAcceptor(schema, context)
+        else:
+            acceptor = ArrayAcceptor()
+    else:
+        raise UnknownSchemaTypeError(schema)
+
+    return acceptor
+
+
+# pylint: disable-next=invalid-name
+def EncapsulatedJsonSchemaAcceptor(schema):
+    """
+    Accept JSON according to a schema, where the JSON is part of a larger text
+    and is delimited by starting line ```json and end line ```.
+    """
+    return SequenceAcceptor(
+        [
+            WaitForAcceptor(TextAcceptor("```json\n")),
+            JsonSchemaAcceptor(schema),
+            TextAcceptor("\n```"),
+        ]
+    )
+
+
+class JsonSchemaAcceptorDriver:
+    """
+    Utility class to drive a JsonSchemaAcceptor
+    """
+
+    class TokenRejected(Exception):
+        """
+        Raised when the token cannot advance any of the current acceptors.
+        """
+
+    class CharacterRejected(Exception):
+        """
+        Raised in character-by-character mode (advance_char method) when the
+        character cannot advance any of the current acceptors.
+        """
+
+    @classmethod
+    def driver_factory_for_model(
+        cls,
+        vocabulary: Iterable[Tuple[int, str]],
+        eos_id: int,
+    ) -> callable:
+        """
+        Sets up the data structures (slow, one time) and returns a factory function
+        that creates JsonSchemaAcceptorDriver objects for the model.
+        """
+        # Make sure the eos token is removed.
+        # Ideally, the caller should not pass any special tokens (bos, eos, unk, pad, ...)
+        vocabulary_list = [
+            (token, fragment) for token, fragment in vocabulary if token != eos_id
+        ]
+        vocabulary_dict = dict(vocabulary_list)
+        vocabulary_trie = TokenAcceptor.prepare_vocabulary(vocabulary_list)
+        prepare_json_acceptor_tries(vocabulary_trie)
+
+        def _factory(
+            schema: dict, is_encapsulated_json: bool = False
+        ) -> JsonSchemaAcceptorDriver:
+            return JsonSchemaAcceptorDriver(
+                vocabulary_dict, vocabulary_trie, eos_id, schema, is_encapsulated_json
+            )
+
+        return _factory
+
+    def __init__(
+        self,
+        vocabulary_dict: dict[int, str],
+        vocabulary_trie: TokenTrie,
+        eos_id: int,
+        schema: dict,
+        is_encapsulated_json: bool = False,
+    ):
+        self.vocabulary = vocabulary_dict
+        self.trie = vocabulary_trie
+        self.eos_id = eos_id
+        if is_encapsulated_json:
+            self.acceptor = EncapsulatedJsonSchemaAcceptor(schema)
+        else:
+            self.acceptor = JsonSchemaAcceptor(schema)
+        self.cursors = self.acceptor.get_cursors()
+        self.debug_max_cursors = 0
+
+    def in_accepted_state(self) -> bool:
+        """
+        Returns True if the acceptor has reached a valid final state.
+        """
+        return any(cursor.in_accepted_state() for cursor in self.cursors)
+
+    def select_valid_tokens(self) -> int:
+        """
+        Given the current valid state(s) of the acceptor, return the tokens
+        in the vocabulary that can advance the acceptor towards another
+        valid state(s).
+        """
+        accepted_token_ids = TokenAcceptor.match_all(self.cursors, self.trie)
+        if self.in_accepted_state():
+            accepted_token_ids |= 1 << self.eos_id
+        return accepted_token_ids
+
+    def debug_select_valid_tokens(self, debug_output_fn=print) -> int:
+        """
+        Same as select_valid_tokens() but prints debug information.
+        """
+        accepted_token_ids = TokenAcceptor.debug_match_all(
+            self.cursors, self.trie, debug_output_fn
+        )
+        if self.in_accepted_state():
+            accepted_token_ids |= 1 << self.eos_id
+        return accepted_token_ids
+
+    def advance_token(self, token):
+        """
+        Advance the state(s) of the acceptor with the chosen token.
+        """
+        if token == self.eos_id:
+            if not self.in_accepted_state():
+                raise JsonSchemaAcceptorDriver.TokenRejected()
+            self.cursors = []
+            return
+        fragment = self.vocabulary[token]
+        cursors = self.cursors
+        for char in fragment:
+            cursors = TokenAcceptor.advance_all(cursors, char)
+            if not cursors:
+                raise JsonSchemaAcceptorDriver.TokenRejected()
+        self.cursors = cursors
+
+    def debug_advance_token(self, token, debug_output_fn=print):
+        """
+        Same as advance_token() but prints debug information.
+        """
+        if token == self.eos_id:
+            if not self.in_accepted_state():
+                raise JsonSchemaAcceptorDriver.TokenRejected()
+            self.cursors = []
+            return
+        fragment = self.vocabulary[token]
+        cursors = self.cursors
+        for char in fragment:
+            cursors = TokenAcceptor.advance_all(cursors, char)
+            ncursors = len(cursors)
+            if ncursors > self.debug_max_cursors:
+                self.debug_max_cursors = ncursors
+            debug_output_fn(f"ADVANCE char={repr(char)} cursors({ncursors})")
+            if ncursors:
+                debug_output_fn("  " + "\n  ".join(repr(c) for c in cursors))
+            if ncursors == 0:
+                raise JsonSchemaAcceptorDriver.TokenRejected()
+        self.cursors = cursors
+
+    def advance_char(self, char):
+        """
+        Advance the state(s) of the acceptor one character at a time.
+        This is useful for applications such as partial JSON parsing.
+        """
+        cursors = TokenAcceptor.advance_all(self.cursors, char)
+        if not cursors:
+            raise JsonSchemaAcceptorDriver.CharacterRejected()
+        self.cursors = cursors
+
+    def get_current_value_paths(self):
+        """
+        This function will return the JSON path(s) for the value(s) that the
+        last accepted character was attached to. More than one path means
+        more than one possible parse for the JSON according to the schema,
+        and it's rare.
+        The value path is useful to know where in the JSON are we accepting a
+        value (string, number, boolean, null) at the moment. An empty array
+        means the last character was a syntactic elements (punctuation,
+        whitespace) or part of the name of a property.
+        Note that this function is mostly useful when advancing character by
+        character, because a token can straddle across states and thus its
+        path is not well-defined.
+        """
+        return [
+           f"${path}"
+           for path in set((
+               cursor.get_value_path()
+               for cursor in self.cursors if cursor.is_in_value()
+           ))
+        ]
+
+

--- a/pylib/vendor/llm_structured_output/util/__init__.py
+++ b/pylib/vendor/llm_structured_output/util/__init__.py
@@ -1,0 +1,4 @@
+from . import bitmap
+from . import output
+from . import tokentrie
+from . import tokenization

--- a/pylib/vendor/llm_structured_output/util/bitmap.py
+++ b/pylib/vendor/llm_structured_output/util/bitmap.py
@@ -1,0 +1,74 @@
+"""
+Utilities to use the bitmap of accepted token ids returned by TokenAcceptor.
+"""
+
+from math import inf
+from typing import Iterable
+
+
+def count_set_bits(bitmap: int) -> int:
+    """
+    Count the number of bits set to one.
+    """
+    # FUTURE: self.ids.bit_count() available from Python 3.10 is said to be 6x faster
+    return bin(bitmap).count("1")
+
+
+def highest_bit_set(bitmap: int) -> int:
+    """
+    Return the index of the highest bit set in the bitmap.
+    """
+    return bitmap.bit_length() - 1
+
+
+def bitmap_complement(bitmap: int, set_size: int = None) -> int:
+    """
+    Negate the bits in the bitmap.
+    Since the bitmap is encoded as a Python int, it can be of arbitrary length.
+    I.e. we don't know how many zeros are above the top set bit. The set_size
+    parameter can be passed to indicate the number of bits in the bitmap (which
+    is akin to the number of members in the set it represents). If unspecified,
+    the top set bit in the bitmap is used as its set size. 
+    """
+    if not set_size:
+        set_size = bitmap.bit_length()
+    return (1 << set_size) - 1 - bitmap
+
+
+def enumerate_set_bits(bitmap: int) -> Iterable[int]:
+    """
+    Generator that yields the indices of the set bits in the bitmap.
+    Note that it does so from highest to lowest.
+    """
+    while bitmap:
+        highest_bit = highest_bit_set(bitmap)
+        yield highest_bit
+        bitmap -= 1 << highest_bit
+
+
+def bias_logits(np, logits, accepted_token_bitmap):
+    """
+    Apply a -inf bias to tokens that will not be accepted.
+    Rather than import here, the np parameters is numpy or a compatible library
+    import, such as mlx.core.
+    """
+    vocab_size = logits.shape[0]
+    highest_token_accepted = highest_bit_set(accepted_token_bitmap)
+    accepted_token_count = count_set_bits(accepted_token_bitmap)
+    # Check whether there's more tokens to be rejected or to be allowed, then do what's less work.
+    if accepted_token_count <= highest_token_accepted / 2:
+        bias = np.full(vocab_size, -inf)
+        indices = np.array([*enumerate_set_bits(accepted_token_bitmap)])
+        bias[indices] = 0
+    else:
+        bias = np.concatenate(
+            [
+                np.full(highest_token_accepted + 1, 0),
+                # All tokens above the highest accepted token are rejected.
+                np.full(vocab_size - highest_token_accepted - 1, -inf),
+            ]
+        )
+        rejected_token_bitmap = bitmap_complement(accepted_token_bitmap)
+        indices = np.array([*enumerate_set_bits(rejected_token_bitmap)])
+        bias[indices] = -inf
+    return np.add(logits, bias)

--- a/pylib/vendor/llm_structured_output/util/output.py
+++ b/pylib/vendor/llm_structured_output/util/output.py
@@ -1,0 +1,74 @@
+# pylint: disable=missing-function-docstring
+"""
+Terminal colored output
+"""
+
+
+def info(*args, **kwargs):
+    print("\033[34mℹ ", end="")
+    print(*args, **kwargs)
+    print("\033[0m", end="")
+
+
+def warning(*args, **kwargs):
+    print("\033[43;37m", end="")
+    print(*args, **kwargs)
+    print("\033[0m", end="")
+
+
+def debug(*args, **kwargs):
+    print("\033[33m", end="")
+    print(*args, **kwargs)
+    print("\033[0m", end="")
+
+
+def debugbold(*args, **kwargs):
+    print("\033[1;33m", end="")
+    print(*args, **kwargs)
+    print("\033[0m", end="")
+
+
+def bold(*args, **kwargs):
+    print("\033[1;30m", end="")
+    print(*args, **kwargs)
+    print("\033[0m", end="")
+
+
+def bolddim(*args, **kwargs):
+    print("\033[1;2;30m", end="")
+    print(*args, **kwargs)
+    print("\033[0m", end="")
+
+
+def boldalt(*args, **kwargs):
+    print("\033[1;36m", end="")
+    print(*args, **kwargs)
+    print("\033[0m", end="")
+
+
+def underline(*args, **kwargs):
+    print("\033[4m", end="")
+    print(*args, **kwargs)
+    print("\033[0m", end="")
+
+
+def inverse(*args, **kwargs):
+    print("\033[7m", end="")
+    print(*args, **kwargs)
+    print("\033[0m", end="")
+
+
+def setfg(r: float, g: float, b: float):
+    """Each of r,g,b must be between 0 and 1"""
+    color = 16 + 36 * round(5 * r) + 6 * round(5 * g) + round(5 * b)
+    print(f"\033[38;5;{color}m", end="")
+
+
+def setbg(r: float, g: float, b: float):
+    """Each of r,g,b must be between 0 and 1"""
+    color = 16 + 36 * round(5 * r) + 6 * round(5 * g) + round(5 * b)
+    print(f"\033[48;5;{color}m", end="")
+
+
+def clear():
+    print("\033[0m", end="")

--- a/pylib/vendor/llm_structured_output/util/tokenization.py
+++ b/pylib/vendor/llm_structured_output/util/tokenization.py
@@ -1,0 +1,59 @@
+"""
+Tokenizer utils.
+"""
+
+from typing import Union
+
+SPIECE_UNDERLINE = "▁"
+
+
+class HuggingfaceTokenizerHelper:
+    """
+    Helper to use Huggingface tokenizers effectively.
+    """
+
+    def __init__(self, tokenizer):
+        """
+        tokenizer is expected to be a Huggingface PreTrainedTokenizer[Fast]
+        """
+        self.tokenizer = tokenizer
+        self.token_has_space_prefix = dict(
+            [
+                (i, fragment[0] == SPIECE_UNDERLINE)
+                for fragment, i in tokenizer.vocab.items()
+            ]
+        )
+
+    def encode_prompt(self, prompt: Union[str, list[dict[str, str]]]) -> list[int]:
+        """
+        Encode the prompt, applying the tokenizer template first if the prompt
+        is a series of messages instead of a straight string.
+        """
+        if isinstance(prompt, str):
+            return self.tokenizer.encode(prompt)
+        if not self.tokenizer.chat_template:
+            return self.tokenizer.encode("\n\n".join(
+                f"{message['role']}: {message['content']}"
+                for message in prompt
+            ))
+        return self.tokenizer.apply_chat_template(prompt)
+
+    def no_strip_decode(self, tokens):
+        """
+        Allows to decode single tokens without removing the initial space.
+        The Huggingface tokenizer doesn't seem to have an easy way to do this.
+        """
+        fragment = self.tokenizer.decode(tokens)
+        if self.token_has_space_prefix[tokens[0]]:
+            return f" {fragment}"
+        else:
+            return fragment
+
+    def extract_vocabulary(self) -> tuple[list[tuple[int, str]], int]:
+        """
+        Extract the vocabulary and eos_token_id from a Huggingface PreTrainedTokenizer.
+        """
+        return (
+            [(i, self.no_strip_decode([i])) for _, i in self.tokenizer.vocab.items()],
+            self.tokenizer.eos_token_id,
+        )

--- a/pylib/vendor/llm_structured_output/util/tokenization.py
+++ b/pylib/vendor/llm_structured_output/util/tokenization.py
@@ -36,7 +36,7 @@ class HuggingfaceTokenizerHelper:
                 f"{message['role']}: {message['content']}"
                 for message in prompt
             ))
-        return self.tokenizer.apply_chat_template(prompt)
+        return self.tokenizer.apply_chat_template(prompt, add_generation_prompt=True)
 
     def no_strip_decode(self, tokens):
         """

--- a/pylib/vendor/llm_structured_output/util/tokentrie.py
+++ b/pylib/vendor/llm_structured_output/util/tokentrie.py
@@ -1,0 +1,156 @@
+"""
+TokenTrie: hold the LLM token vocabulary in a prefix tree in otder to perform
+operations over the whole vocabulary or parts of it in logarithmic time instead
+of linear.
+"""
+
+from __future__ import annotations
+from collections import namedtuple
+from typing import Callable, Iterable, Tuple
+
+
+TokenTrieStats = namedtuple(
+    "TokenTrieStats", ["tokenids", "trienodes", "trieleaves", "triedepth"]
+)
+
+
+class TokenTrie:
+    """
+    Access the tokens in a vocabulary hierarchically by prefix.
+    Ids are stored as a bitmap with bits set to one meaning id is present.
+    """
+
+    def __init__(self):
+        self.children: dict[str, TokenTrie] = {}
+        self.ids: int = 0
+
+    def insert_all(self, vocabulary: Iterable[Tuple[int, str]]):
+        """
+        Insert all the tokens in the vocabulary in the trie, with the id of
+        each token being its index in the vocabulary.
+        """
+        for _id, token in vocabulary:
+            if len(token) > 0:
+                self.insert(token, _id)
+
+    def insert(self, token, _id):
+        """
+        Insert one token in the trie, with the given id.
+        """
+        if len(token) == 0:
+            self.ids |= 1 << _id
+        else:
+            head, tail = token[0], token[1:]
+            child = self.children.get(head, self.__class__())
+            child.insert(tail, _id)
+            self.children[head] = child
+
+    def insert_ids(self, token, ids):
+        """
+        Insert a token in the trie, with the given id set.
+        This is useful e.g. when collapsing multiple branches into one.
+        """
+        if len(token) == 0:
+            self.ids |= ids
+        else:
+            head, tail = token[0], token[1:]
+            child = self.children.get(head, self.__class__())
+            child.insert_ids(tail, ids)
+            self.children[head] = child
+
+    def collect_ids(self) -> set[int]:
+        """
+        Returns a set with the ids of the token(s) in this node and all the
+        nodes below it.
+        """
+        ids = self.ids
+        for child in self.children.values():
+            ids |= child.collect_ids()
+        return ids
+
+    def dfs(self, prefix="") -> Iterable[tuple[str, int]]:
+        """
+        Traverse the trie depth-first, yielding (token, ids) tuples.
+        """
+        if self.ids:
+            yield (prefix, self.ids)
+        for char, child in self.children.items():
+            yield from child.dfs(prefix + char)
+
+    def map(self, map_fn: Callable[[str, int], str]) -> TokenTrie:
+        """
+        Return a trie where the characters are mapped to other characters using a
+        function. This is useful for example to collapse a tree into a smaller one
+        by pruning or merging branches where the characters are equivalent for a
+        particular use case. The mapping function is passed a character to map, and
+        the recursion level in the tree, and it can return True to preserve the
+        branch of the tree as is, None to prune it, or a replacement character.
+        If the latter, the branch will be recursed upon and stored under the
+        replacement branch.
+        """
+        return self._map(map_fn, self.__class__())
+
+    def _map(
+        self, map_fn: Callable[[str, int], str], mapped_trie: TokenTrie, level: int = 0
+    ) -> TokenTrie:
+        """
+        Internal implementation of map()
+        """
+        mapped_trie.ids |= self.ids
+        for char, child in self.children.items():
+            mapped_char = map_fn(char, level)
+            if mapped_char is True:
+                # If the mapping function returns True, preserve the original branch
+                mapped_trie.children[char] = child
+            elif mapped_char is None:
+                # If the mapping function returns None, prune the original branch
+                pass
+            else:
+                # Map the branch to a new character, e.g. merge several chars into one
+                mapped_child = mapped_trie.children.get(
+                    mapped_char, mapped_trie.__class__()
+                )
+                # pylint: disable-next=protected-access
+                mapped_trie.children[mapped_char] = child._map(
+                    map_fn, mapped_child, level + 1
+                )
+        return mapped_trie
+
+    def _id_count(self) -> int:
+        """
+        Returns the number of ids in this node
+        """
+        # FUTURE: self.ids.bit_count() available from Python 3.10 is said to be 6x faster
+        return bin(self.ids).count("1")
+
+    def max_depth(self) -> int:
+        """
+        Return the max depth of any branch on the trie, i.e. the length of the longest token.
+        """
+        return max((child.max_depth() for child in self.children.values()), default=0) + 1
+
+    def stats(self) -> TokenTrieStats:
+        """
+        Compute and return statistics on the trie, for debugging purposes.
+        """
+        ids = self._id_count()
+        nodes = 1
+        leaves = 0
+        depth = 0
+        if len(self.children) == 0:
+            leaves = 1
+        else:
+            for branch in self.children.values():
+                branch_ids, branch_nodes, branch_leaves, branch_depth = branch.stats()
+                ids += branch_ids
+                nodes += branch_nodes
+                leaves += branch_leaves
+                depth = max(depth, branch_depth)
+        return TokenTrieStats(
+            tokenids=ids, trienodes=nodes, trieleaves=leaves, triedepth=depth + 1
+        )
+
+    def __repr__(self):
+        id_count = self._id_count()
+        child_count = len(self.children)
+        return f"{super().__repr__()}({id_count=}, {child_count=})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "mlx_lm>=0.20.6; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.8' and platform_release >= '22.6.0'",
   # "mlx>=0.16.0;platform_version=='arm64'",
   # "mlx_lm>=0.16.0;platform_version=='arm64'",
-  "llm-structured-output>=0.0.19",
   "ogbujipt>=0.9.3",
   "fastapi>=0.115.3",
   "click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
   # MLX libraries are only installed on Apple Silicon Macs running macOS 13.5+ with Python 3.8+, as requied
   # platform_release >= '22.6.0': Corresponds to macOS 13.5 or later
   # FOr more on environment markers see: https://hatch.pypa.io/dev/config/dependency/#environment-markers
-  "mlx>=0.19.1; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.8' and platform_release >= '22.6.0'",
-  "mlx_lm>=0.19.2; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.8' and platform_release >= '22.6.0'",
+  "mlx>=0.21.1; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.8' and platform_release >= '22.6.0'",
+  "mlx_lm>=0.20.6; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.8' and platform_release >= '22.6.0'",
   # "mlx>=0.16.0;platform_version=='arm64'",
   # "mlx_lm>=0.16.0;platform_version=='arm64'",
   "llm-structured-output>=0.0.19",

--- a/test/quick_check.py
+++ b/test/quick_check.py
@@ -1,7 +1,9 @@
 '''
 python test/quick_check.py mlx-community/Hermes-2-Theta-Llama-3-8B-4bit
-'''
 
+Requires: pip install google-re2
+'''
+# FIXME: Come up with example that doesn't require other external libs such as re2
 import sys
 import asyncio
 

--- a/test/test_model_manager.py
+++ b/test/test_model_manager.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # test/test_model_manager.py
 import json
-from unittest.mock import Mock, patch
+from unittest.mock import patch  # , Mock
 
 import pytest
 
@@ -13,6 +13,9 @@ from toolio.llm_helper import model_manager
 
 @pytest.mark.asyncio
 async def test_model_manager_completion(mock_model):
+    '''
+    Test the completion method of the model manager, which should return the final response from the model
+    '''
     mm = model_manager('test_path')
     mock_model.completion.return_value = iter([
         {'op': 'evaluatedPrompt', 'token_count': 2},


### PR DESCRIPTION
Just to make sure we can manage our own cadence in keeping up with upstream mlx, mlx_lm and their rapid changes, it makes sense to "vendor" [llm-structured-output](https://github.com/otriscon/llm-structured-output) into our codebase.